### PR TITLE
Fix typo in Lecture 12

### DIFF
--- a/lectures/lec12.tex
+++ b/lectures/lec12.tex
@@ -187,7 +187,7 @@ set of goals:
       \item \textbf{Forward secrecy with respect
         to key compromise:} if an attacker
         steals the secrets stored on the client or the server, 
-        the attacker cannot encrypt past traffic.
+        the attacker cannot decrypt past traffic.
         \marginnote{To provide forward secrecy, modern cryptographic
         protocols use long-term secrets only for signing---not for
         encryption.


### PR DESCRIPTION
I believe it should be decrypt instead of encrypt?