### PR TITLE
Fix typo in digital signature

### DIFF
--- a/lectures/lec05.tex
+++ b/lectures/lec05.tex
@@ -311,7 +311,7 @@ we can say:
 
 The events that $\calA$ breaks the signature scheme
 and that either of these failures occur are all \emph{independent}.
-Then if $\calA$ breaks the one-way function with probability $\epsilon$,
+Then if $\calA$ breaks the one-time security of the Lamport signature scheme with probability $\epsilon$,
 our one-way-function adversary $\calB$
 inverts the one-way function with probability
 \[ \epsilon_\text{one-way} = \epsilon \cdot \frac{1}{2} \cdot \frac{1}{n}.\]


### PR DESCRIPTION
I believe here's a typo, as $\mathcal{A}$ has always been assumed to break the signature scheme everywhere else in the proof.